### PR TITLE
Missing status in invoice.json

### DIFF
--- a/json/v1.0/invoice.json
+++ b/json/v1.0/invoice.json
@@ -37,7 +37,7 @@
     "status":{
       "description": "Defaults to draft for new documents, unless otherwise stated. For new documents with status 'open' or 'closed' or doc where the status changes away from draft, following fields are set if empty: number(next in number schema), date(today), due date(due_days must be given). Only draft documents can be deleted.",
       "default":"draft",
-      "enum":["draft","open","closed"],
+      "enum":["draft","open","closed","overdue"],
       "type":"string"
     },
     "external_ref":{


### PR DESCRIPTION
There's a missing status attribute in the enum of invoice.json
