### PR TITLE
callback_url payload location

### DIFF
--- a/json/v1.0/sub.json
+++ b/json/v1.0/sub.json
@@ -1,7 +1,7 @@
 {"type":"object",
   "title": "sub",
   "name": "sub",
-  "description": "Subscribe to push notifications(webhooks) about object livecycle events like new, update or delete. Only returns subscription for the current app, so you MUST be using oAuth. When a user removes your app its subs are also deleted. <br/>To register you must supply <br/>- callback_url: receives a base64 encode string containing a JSON object with the object in it's latest state, the user_id & subdomain, company_id, hmac-signed with your app secret.<br/>- channel: defining the event, made up of the SINGULAR object name and the action: invoice.delete, payment.new<br/> - register auth_permissions: An app MUST request non-api permissions f.ex.: clients:create. Perms(on company,app,user,team) are checked before any publishing, so if a user cannot create clients in the interface, his apps will not receive any callbacks.",
+  "description": "Subscribe to push notifications(webhooks) about object livecycle events like new, update or delete. Only returns subscription for the current app, so you MUST be using oAuth. When a user removes your app its subs are also deleted. <br/>To register you must supply <br/>- callback_url: receives a POST containing a JSON object with the object in it's latest state, the user_id & subdomain, company_id, hmac-signed with your app secret as base64 encode string.<br/>- channel: defining the event, made up of the SINGULAR object name and the action: invoice.delete, payment.new<br/> - register auth_permissions: An app MUST request non-api permissions f.ex.: clients:create. Perms(on company,app,user,team) are checked before any publishing, so if a user cannot create clients in the interface, his apps will not receive any callbacks.",
   "properties":{
     "id":{
       "description":"Unique identifier - UUID",
@@ -18,7 +18,7 @@
       "maxLength": 100
     },
     "callback_url":{
-      "description": "An url receiving the notification. The url MUST be within the url of the current app and receives a POST with a single signed_request parameter containing an base64 encoded JSON object.",
+      "description": "An url receiving the notification. The url MUST be within the url of the current app and receives a POST having the signed_request parameter containing an base64 encoded JSON object in the body.",
       "type":"string",
       "format":"uri",
       "required":true,


### PR DESCRIPTION
when calling the `callback_url` the `signed_request`-parameter will be in the body of the POST request.